### PR TITLE
Uncaught ipbus timeout in get_info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-cmake/
 
 cmake_minimum_required(VERSION 3.12)
-project(hermesmodules VERSION 1.0.2)
+project(hermesmodules VERSION 1.0.3)
 
 find_package(daq-cmake REQUIRED)
 

--- a/plugins/HermesController.cpp
+++ b/plugins/HermesController.cpp
@@ -64,29 +64,32 @@ void
 HermesController::get_info(opmonlib::InfoCollector& ci, int /* level */)
 {
 
-  
-  hermescontrollerinfo::Info info;
-  info.total_amount = m_total_amount;
-  info.amount_since_last_get_info_call = m_amount_since_last_get_info_call.exchange(0);
+  try {
+    hermescontrollerinfo::Info info;
+    info.total_amount = m_total_amount;
+    info.amount_since_last_get_info_call = m_amount_since_last_get_info_call.exchange(0);
 
-  ci.add(info);
+    ci.add(info);
 
-  const auto& core_info = m_core_controller->get_info();
+    const auto& core_info = m_core_controller->get_info();
 
-  for ( uint16_t i(0); i<core_info.n_mgt; ++i){
+    for ( uint16_t i(0); i<core_info.n_mgt; ++i){
 
-    auto geo_info = m_core_controller->read_link_geo_info(i);
+      auto geo_info = m_core_controller->read_link_geo_info(i);
 
-    // Create a sub-collector per linkg
-    opmonlib::InfoCollector link_ci;
-    
-    hermescontrollerinfo::LinkStats link_stats;
+      // Create a sub-collector per linkg
+      opmonlib::InfoCollector link_ci;
+      
+      hermescontrollerinfo::LinkStats link_stats;
 
-    // get link statis
-    link_ci.add(m_core_controller->read_link_stats(i));
+      // get link statis
+      link_ci.add(m_core_controller->read_link_stats(i));
 
-    // 
-    ci.add(fmt::format("hermes_det{}_crt{}_slt{}_lnk{}",geo_info.detid, geo_info.crateid, geo_info.slotid, i), link_ci);
+      // 
+      ci.add(fmt::format("hermes_det{}_crt{}_slt{}_lnk{}",geo_info.detid, geo_info.crateid, geo_info.slotid, i), link_ci);
+    }
+  } catch ( const uhal::exception:exception& e ) {
+    ers::warning(FailedToRetrieveStats(ERS_HERE, "IPBus exception"));
   }
  }
 

--- a/plugins/HermesController.cpp
+++ b/plugins/HermesController.cpp
@@ -17,6 +17,7 @@
 #include <netinet/ether.h>
 #include <arpa/inet.h>
 #include <fmt/core.h>
+#include "logging/Logging.hpp"
 
 
 

--- a/plugins/HermesController.cpp
+++ b/plugins/HermesController.cpp
@@ -88,7 +88,7 @@ HermesController::get_info(opmonlib::InfoCollector& ci, int /* level */)
       // 
       ci.add(fmt::format("hermes_det{}_crt{}_slt{}_lnk{}",geo_info.detid, geo_info.crateid, geo_info.slotid, i), link_ci);
     }
-  } catch ( const uhal::exception:exception& e ) {
+  } catch ( const uhal::exception::exception& e ) {
     ers::warning(FailedToRetrieveStats(ERS_HERE, "IPBus exception"));
   }
  }

--- a/plugins/HermesController.hpp
+++ b/plugins/HermesController.hpp
@@ -36,9 +36,9 @@ ERS_DECLARE_ISSUE(hermesmodules,
                   );
 
 ERS_DECLARE_ISSUE(hermesmodules,
-                  FailedToRetrieveStats
-                  "Failed to retrieve hermes code stats" << msg,
-                  ((std::string)msg)
+                  FailedToRetrieveStats,
+                  "Failed to retrieve hermes code stats" << what,
+                  ((std::string)what)
                   );
                   
 namespace hermesmodules {

--- a/plugins/HermesController.hpp
+++ b/plugins/HermesController.hpp
@@ -35,6 +35,12 @@ ERS_DECLARE_ISSUE(hermesmodules,
                   ((uint16_t)cfg_n_links)((uint16_t)cfg_n_links_unique)
                   );
 
+ERS_DECLARE_ISSUE(hermesmodules,
+                  FailedToRetrieveStats
+                  "Failed to retrieve hermes code stats" << msg,
+                  ((std::string)msg)
+                  );
+                  
 namespace hermesmodules {
 
 class HermesController : public dunedaq::appfwk::DAQModule


### PR DESCRIPTION
Ipbus timeout can be occasionally emitted in the monitoring loop if the endpoint becomes temporarily unavailable.
These exceptions were not caught causing the daq application to die.
Now they are.