### PR TITLE
Include logging/Logging.hpp whenever ERS issues are declared, includi…

### DIFF
--- a/include/hermesmodules/HermesCoreController.hpp
+++ b/include/hermesmodules/HermesCoreController.hpp
@@ -3,7 +3,7 @@
 #define HERMESMODULES_INCLUDE_HERMESCORECONTROLLER_HPP_
 
 #include "ers/Issue.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include "uhal/uhal.hpp"
 
 #include "hermesmodules/opmon/hermescontroller.pb.h"

--- a/include/hermesmodules/HermesCoreController.hpp
+++ b/include/hermesmodules/HermesCoreController.hpp
@@ -3,6 +3,7 @@
 #define HERMESMODULES_INCLUDE_HERMESCORECONTROLLER_HPP_
 
 #include "ers/Issue.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include "uhal/uhal.hpp"
 
 #include "hermesmodules/opmon/hermescontroller.pb.h"

--- a/plugins/HermesModule.hpp
+++ b/plugins/HermesModule.hpp
@@ -12,6 +12,7 @@
 #define HERMESMODULES_PLUGINS_HERMESCORECONTROLLER_HPP_
 
 #include "appfwk/DAQModule.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include "hermesmodules/HermesCoreController.hpp"
 

--- a/plugins/HermesModule.hpp
+++ b/plugins/HermesModule.hpp
@@ -12,7 +12,7 @@
 #define HERMESMODULES_PLUGINS_HERMESCORECONTROLLER_HPP_
 
 #include "appfwk/DAQModule.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include "hermesmodules/HermesCoreController.hpp"
 


### PR DESCRIPTION
…ng note on why (TLOG() << ERSIssue only works when Logging.hpp included first)