### PR TITLE
Phys reset at conf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 cmake_minimum_required(VERSION 3.12)
-project(hermesmodules VERSION 2.2.2)
+project(hermesmodules VERSION 2.2.3)
 
 find_package(daq-cmake REQUIRED)
 

--- a/include/hermesmodules/HermesCoreController.hpp
+++ b/include/hermesmodules/HermesCoreController.hpp
@@ -21,6 +21,13 @@ ERS_DECLARE_ISSUE(hermesmodules,
                   ((int)bid)
                   );
 
+
+ERS_DECLARE_ISSUE(hermesmodules,
+                  MgtDoesNotExist,
+                  "Hermes MGT " << mgtid << " does not exist",
+                  ((int)mgtid)
+                  );
+
 ERS_DECLARE_ISSUE(hermesmodules,
                   MagicNumberError,
                   "Hermes Magic number failed " << found << " (" << expected << ")",

--- a/src/HermesCoreController.cpp
+++ b/src/HermesCoreController.cpp
@@ -125,9 +125,16 @@ HermesCoreController::reset(bool nuke) {
     m_readout.getNode("csr.ctrl.soft_rst").write(0x0);
     m_readout.getClient().dispatch();
 
-    m_readout.getNode('pcs_pma.debug.csr.ctrl.phy_reset').write(0x1)
-    m_readout.getNode('pcs_pma.debug.csr.ctrl.phy_reset').write(0x0)
-    m_readout.getClient().dispatch()
+    // Check the ethernet core status
+    auto eth_rdy = m_readout.getNode("tx_path.tx_mux.csr.stat.eth_rdy").read();
+    m_readout.getClient().dispatch();
+
+    // If the ethernet core is not ready, issue a phy reset
+    if ( !eth_rdy ) {
+      m_readout.getNode("pcs_pma.debug.csr.ctrl.phy_reset").write(0x1);
+      m_readout.getNode("pcs_pma.debug.csr.ctrl.phy_reset").write(0x0);
+      m_readout.getClient().dispatch();
+    }
 
 }
 

--- a/src/HermesCoreController.cpp
+++ b/src/HermesCoreController.cpp
@@ -56,11 +56,13 @@ HermesCoreController::load_hw_info() {
   m_core_info.ref_freq = ref_freq.value();
 
   // Extra info
-  m_core_info.srcs_per_mux = m_core_info.n_src/m_core_info.n_mgt;
+  m_core_info.srcs_per_mux = m_core_info.n_src;
 
   fmt::print("Number of links: {}\n", m_core_info.n_mgt);
   fmt::print("Number of sources: {}\n", m_core_info.n_src);
   fmt::print("Reference freq: {}\n", m_core_info.ref_freq);
+  fmt::print("Sources per mux:{}\n",  m_core_info.srcs_per_mux);
+
 }
 
 
@@ -91,8 +93,8 @@ HermesCoreController::sel_tx_mux_buf(uint16_t i) {
 //-----------------------------------------------------------------------------
 void
 HermesCoreController::sel_udp_core(uint16_t i) {
-  if ( i >= m_core_info.n_src ) {
-    throw InputBufferDoesNotExist(ERS_HERE, i);
+  if ( i >= m_core_info.n_mgt ) {
+    throw MgtDoesNotExist(ERS_HERE, i);
   }
 
   m_readout.getNode("tx_path.csr_udp_core.ctrl.udp_core_sel").write(i);
@@ -275,6 +277,7 @@ HermesCoreController::config_fake_src(uint16_t link, uint16_t n_src, uint16_t da
   auto was_en_buf = m_readout.getNode("tx_path.tx_mux.csr.ctrl.en_buf").read();
   m_readout.getNode("tx_path.tx_mux.csr.ctrl.en_buf").write(0x0);
   m_readout.getClient().dispatch();
+
 
 
   for ( size_t src_id(0); src_id<m_core_info.srcs_per_mux; ++src_id) {

--- a/src/HermesCoreController.cpp
+++ b/src/HermesCoreController.cpp
@@ -125,6 +125,10 @@ HermesCoreController::reset(bool nuke) {
     m_readout.getNode("csr.ctrl.soft_rst").write(0x0);
     m_readout.getClient().dispatch();
 
+    m_readout.getNode('pcs_pma.debug.csr.ctrl.phy_reset').write(0x1)
+    m_readout.getNode('pcs_pma.debug.csr.ctrl.phy_reset').write(0x0)
+    m_readout.getClient().dispatch()
+
 }
 
 


### PR DESCRIPTION
# Description

This PR adds a reset of the hermes core physical layer at conf, if the core is in error

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ x Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

