### PR TITLE
wrk: version v2.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 cmake_minimum_required(VERSION 3.12)
-project(hermesmodules VERSION 2.2.4)
+project(hermesmodules VERSION 2.3.0)
 
 find_package(daq-cmake REQUIRED)
 


### PR DESCRIPTION
# Description

Version bump for hermesmodules: `v2.2.4` -> `v2.3.0`, prepared for the `fddaq-v5.7.0` build.

This bump removes an obsolete moo/jsonnet config-gen script, its python helper, and the associated schema, as part of an org-wide cleanup effort.

**Classification note:** An automated analysis flagged this removal as potentially **MAJOR/breaking**, since it deletes a config-gen script, helper, and schema. However, the maintainer has explicitly reviewed this and determined it does **not** warrant a major version bump — it has been classified **MINOR** by explicit maintainer decision.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

_Comments: classified MINOR by explicit maintainer decision (see note above); this is a version-bump PR only._

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_No test runs are being claimed as part of this automated version-bump PR._

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

---

> [!IMPORTANT]
> Tag `v2.3.0` has already been pushed and points at the head commit of this
> branch. **Please merge this PR with a merge commit — do not squash or rebase.**
> Squashing or rebasing would leave the published tag pointing at a commit that
> is not an ancestor of `develop`.

## Version transition

- Previous version: `v2.2.4`
- New version: `v2.3.0`
- Tag: `v2.3.0` (already pushed, points at branch tip `0655afe335dcc792c2d0fcb549110c081d0e4bc1`)
- Commits on this branch ahead of `develop`: 1

## Impact Radius

Removal of an obsolete moo/jsonnet config-gen script, python helper, and schema, as part of an org-wide cleanup. Classified MINOR by explicit maintainer decision (see classification note above), despite automated analysis suggesting MAJOR/breaking due to the removed config-gen artifacts.

## Release Notes

Version bump for the `fddaq-v5.7.0` build: removes an obsolete moo/jsonnet config-gen script, its python helper, and the associated schema (org-wide cleanup).

## Version-file diff

```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 545b070..a307f41 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 cmake_minimum_required(VERSION 3.12)
-project(hermesmodules VERSION 2.2.4)
+project(hermesmodules VERSION 2.3.0)
 
 find_package(daq-cmake REQUIRED)
```
